### PR TITLE
Fix Carrier Lookup + Improve Tests

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -30,7 +30,7 @@ Imports:
     progress
 URL: https://github.com/simonpcouch/anyflights
 BugReports: https://github.com/simonpcouch/anyflights/issues
-RoxygenNote: 7.1.1
+RoxygenNote: 7.1.2
 Encoding: UTF-8
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -7,6 +7,7 @@ To be released as 0.3.2.
 * Add information about R session timeout option in the error message when
 `utils::download.file()` fails (#13 by `@patrickvossler18`)
 * Transition continuous integration from Travis to GitHub Actions
+* Fix broken URLs for `get_airlines()` data (#14, #15 by `@leoohyama` and `@alex-gable`)
 
 ## v 0.3.1
 

--- a/R/as_flights_package.R
+++ b/R/as_flights_package.R
@@ -17,13 +17,37 @@
 #' supplied data.
 #' 
 #' @export
-as_flights_package <- function(data, name = make.names(deparse(substitute(data)))) {
+as_flights_package <- function(data, name = make.names(deparse(substitute(data))), ...) {
   
   check_as_flights_package_arguments(data, name)
   
+  d <- list(...)
+  
+  if(!(is.null(d$create_path))) {
+    name <- paste(c(as.character(d$create_path), name), collapse = "/")
+  } 
+  
+  if(!(is.null(d$check_name))) {
+    cn <- d$check_name
+  } else {
+    cn <- TRUE
+  }
+  
+  if(!(is.null(d$use_rstudio))) {
+    rs <- d$use_rstudio
+  } else {
+    # only attempt to create it if we're really sure we can
+    if (rstudioapi::isAvailable() && rlang::is_interactive()) {
+      rs <- TRUE
+    } else {
+      warning_glue("the session is not in an appropriate state to create an .RProj file",
+                   "create one manually using rstudioapi::initializeProject()")
+      rs <- FALSE
+    }
+  }
+  
   usethis::create_package(
-    name,
-    open = FALSE,
+    path = name,
     field = list(
       `Authors@R` = 'c(
       person("Simon P.", "Couch", , "simonpatrickcouch@gmail.com", c("aut", "cre")),
@@ -41,7 +65,10 @@ as_flights_package <- function(data, name = make.names(deparse(substitute(data))
       `License` = "CC0",
       `URL` = "http://github.com/simonpcouch/anyflights",
       `BugReports` = "https://github.com/simonpcouch/anyflights/issues",
-      `Suggests` = "anyflights")
+      `Suggests` = "anyflights"),
+    rstudio = rs,
+    check_name = cn,
+    open = FALSE
   )
   
   save_flights_data(data, name)

--- a/R/as_flights_package.R
+++ b/R/as_flights_package.R
@@ -17,37 +17,13 @@
 #' supplied data.
 #' 
 #' @export
-as_flights_package <- function(data, name = make.names(deparse(substitute(data))), ...) {
+as_flights_package <- function(data, name = make.names(deparse(substitute(data)))) {
   
   check_as_flights_package_arguments(data, name)
   
-  d <- list(...)
-  
-  if(!(is.null(d$create_path))) {
-    name <- paste(c(as.character(d$create_path), name), collapse = "/")
-  } 
-  
-  if(!(is.null(d$check_name))) {
-    cn <- d$check_name
-  } else {
-    cn <- TRUE
-  }
-  
-  if(!(is.null(d$use_rstudio))) {
-    rs <- d$use_rstudio
-  } else {
-    # only attempt to create it if we're really sure we can
-    if (rstudioapi::isAvailable() && rlang::is_interactive()) {
-      rs <- TRUE
-    } else {
-      warning_glue("the session is not in an appropriate state to create an .RProj file",
-                   "create one manually using rstudioapi::initializeProject()")
-      rs <- FALSE
-    }
-  }
-  
   usethis::create_package(
     path = name,
+    open = FALSE,
     field = list(
       `Authors@R` = 'c(
       person("Simon P.", "Couch", , "simonpatrickcouch@gmail.com", c("aut", "cre")),
@@ -65,10 +41,7 @@ as_flights_package <- function(data, name = make.names(deparse(substitute(data))
       `License` = "CC0",
       `URL` = "http://github.com/simonpcouch/anyflights",
       `BugReports` = "https://github.com/simonpcouch/anyflights/issues",
-      `Suggests` = "anyflights"),
-    rstudio = rs,
-    check_name = cn,
-    open = FALSE
+      `Suggests` = "anyflights")
   )
   
   save_flights_data(data, name)

--- a/R/get_airlines.R
+++ b/R/get_airlines.R
@@ -15,10 +15,11 @@
 #' 
 #' @return A data frame with <2k rows and 2 variables:
 #' \describe{
-#' \item{carrier}{Two letter abbreviation}
+#' \item{carrier}{Two or three length letter or number abbreviation. In cases whgere the the Unique Carrier Code has been use more than once, a suffix is added.
+#'                ex. ML, ML (1). This list matches the `Reporting_Airline` field in the BTS documentation for the flights data set}
 #' \item{name}{Full name}
 #' }
-#' @source \url{http://www.transtats.bts.gov/DL_SelectFields.asp?Table_ID=236}
+#' @source \url{https://www.transtats.bts.gov/Download_Lookup.asp?Y11x72=Y_haVdhR_PNeeVRef}
 #' 
 #' @examples
 #' 
@@ -48,8 +49,8 @@ get_airlines <- function(dir = NULL, flights_data = NULL) {
   flights_data <- parse_flights_data_arg(flights_data)
   
   # base url for the airlines dataset
-  airlines_url <- paste0("http://www.transtats.bts.gov/Download_Lookup.asp?",
-                         "Lookup=L_UNIQUE_CARRIERS")
+  airlines_url <- paste0("https://www.transtats.bts.gov/Download_Lookup.asp?",
+                         "Y11x72=Y_haVdhR_PNeeVRef")
   
   # check if the url is active
   if(!url_exists(airlines_url)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -215,7 +215,7 @@ download_month <- function(year, month, dir, flight_exdir, pb, diff_fn) {
   
   # download the file
   download_file_wrapper(fl_url, flight_temp, quiet = TRUE)
-
+ 
   # ...and unzip it
   flight_files <- utils::unzip(flight_temp, list = TRUE)
   
@@ -239,7 +239,9 @@ download_month <- function(year, month, dir, flight_exdir, pb, diff_fn) {
 get_flight_data <- function(path, station) {
   
   # read in the data
-  suppressMessages(vroom::vroom(path, progress = FALSE)) %>%
+  suppressMessages(vroom::vroom(path,
+                   progress = FALSE,
+                   show_col_types = FALSE)) %>%
     # select relevant columns
     dplyr::select(
       year = Year, 

--- a/man/as_flights_package.Rd
+++ b/man/as_flights_package.Rd
@@ -4,7 +4,7 @@
 \alias{as_flights_package}
 \title{Generate a Data Package from `anyflights` Data}
 \usage{
-as_flights_package(data, name = make.names(deparse(substitute(data))))
+as_flights_package(data, name = make.names(deparse(substitute(data))), ...)
 }
 \arguments{
 \item{data}{A named list of dataframes outputted by 

--- a/man/as_flights_package.Rd
+++ b/man/as_flights_package.Rd
@@ -4,7 +4,7 @@
 \alias{as_flights_package}
 \title{Generate a Data Package from `anyflights` Data}
 \usage{
-as_flights_package(data, name = make.names(deparse(substitute(data))), ...)
+as_flights_package(data, name = make.names(deparse(substitute(data))))
 }
 \arguments{
 \item{data}{A named list of dataframes outputted by 

--- a/man/get_airlines.Rd
+++ b/man/get_airlines.Rd
@@ -4,7 +4,7 @@
 \alias{get_airlines}
 \title{Query nycflights13-Like Airlines Data}
 \source{
-\url{http://www.transtats.bts.gov/DL_SelectFields.asp?Table_ID=236}
+\url{https://www.transtats.bts.gov/Download_Lookup.asp?Y11x72=Y_haVdhR_PNeeVRef}
 }
 \usage{
 get_airlines(dir = NULL, flights_data = NULL)
@@ -21,7 +21,8 @@ If not supplied, all carriers/planes will be returned.}
 \value{
 A data frame with <2k rows and 2 variables:
 \describe{
-\item{carrier}{Two letter abbreviation}
+\item{carrier}{Two or three length letter or number abbreviation. In cases whgere the the Unique Carrier Code has been use more than once, a suffix is added.
+               ex. ML, ML (1). This list matches the `Reporting_Airline` field in the BTS documentation for the flights data set}
 \item{name}{Full name}
 }
 }

--- a/tests/testthat/test-7-as-flights-package.R
+++ b/tests/testthat/test-7-as-flights-package.R
@@ -11,13 +11,19 @@ test_that("as_flights_package works", {
                     planes = dplyr::sample_n(nycflights13::planes, 30),
                     airlines = nycflights13::airlines)
   
-  as_flights_package(test_data, "testflights13")
+  create_path <- tempdir()
   
-  expect_true(file.exists("testflights13/R/flights.R"))
-  expect_true(file.exists("testflights13/man/flights.Rd"))
-  expect_true(file.exists("testflights13/data/flights.rda"))
-  expect_true(file.exists("testflights13/testflights13.Rproj"))
+  as_flights_package(test_data, "testflights13", 
+                     create_path = create_path,
+                     check_name = FALSE,
+                     use_rstudio = FALSE)
   
-  unlink("testflights13", recursive = TRUE)
+  package_path = paste0(create_path, "/testflights13")
+  
+  expect_true(file.exists(paste0(package_path, "/R/flights.R")))
+  expect_true(file.exists(paste0(package_path, "/man/flights.Rd")))
+  expect_true(file.exists(paste0(package_path, "/data/flights.rda")))
+  
+  unlink(package_path, recursive = TRUE)
 
 })

--- a/tests/testthat/test-7-as-flights-package.R
+++ b/tests/testthat/test-7-as-flights-package.R
@@ -1,7 +1,7 @@
 context("as_flights_package")
 
 test_that("as_flights_package works", {
-
+  
   skip_on_cran()
   skip_on_ci()
   
@@ -11,19 +11,13 @@ test_that("as_flights_package works", {
                     planes = dplyr::sample_n(nycflights13::planes, 30),
                     airlines = nycflights13::airlines)
   
-  create_path <- tempdir()
+  as_flights_package(test_data, "testflights13")
   
-  as_flights_package(test_data, "testflights13", 
-                     create_path = create_path,
-                     check_name = FALSE,
-                     use_rstudio = FALSE)
+  expect_true(file.exists("testflights13/R/flights.R"))
+  expect_true(file.exists("testflights13/man/flights.Rd"))
+  expect_true(file.exists("testflights13/data/flights.rda"))
+  expect_true(file.exists("testflights13/testflights13.Rproj"))
   
-  package_path = paste0(create_path, "/testflights13")
+  unlink("testflights13", recursive = TRUE)
   
-  expect_true(file.exists(paste0(package_path, "/R/flights.R")))
-  expect_true(file.exists(paste0(package_path, "/man/flights.Rd")))
-  expect_true(file.exists(paste0(package_path, "/data/flights.rda")))
-  
-  unlink(package_path, recursive = TRUE)
-
 })


### PR DESCRIPTION
Well, this started as updating the link for `get_airlines` addressing #14. That was relatively straightforward. There were a number of different Unique Carrier Code lookup tables to use but I chose this one beacause it was:

1. the most comprehensive
2. matched the existing structure without any new data manipulation

As I ran the tests to ensure they passed, I noticed that test 7 wasn't passing because `usethis::create_package` was prompting to ensure we really actually wanted to create our test package in the project test root. I worked around this by allowing the user (including the test) to specify where they wanted to create their flight-data-package.

The one caveat here is that there was a test to ensure that an `.RProj` file was created. I took the liberty of removing that because:

1. it only verified existing behavior of the function it called - i.e. `usethis::create_package` will _always_ create an `.Rproj` file unless it's told not to
2. an `.Rproj` file is not at all necessary when creating a package. 

The function now alerts the user if they intended to create that file and weren't able to, and tells them how to address that if so desired. The default behavior remains the same, and all of this likely amounts to an edge case. 

I wasn't able to resolve the numerous `vroom` warnings about mismatched types. I think creating a `cols` spec might help, but it could also be an issue with the source data.

Let me know if you'd like me to amend this in any way or if you have pointers for how I can improve it! Feel free to take the parts you like and discard the rest

-Alex 