### PR TITLE
(re-)implement as_flights_pacakges test patch

### DIFF
--- a/R/as_flights_package.R
+++ b/R/as_flights_package.R
@@ -17,13 +17,37 @@
 #' supplied data.
 #' 
 #' @export
-as_flights_package <- function(data, name = make.names(deparse(substitute(data)))) {
+as_flights_package <- function(data, name = make.names(deparse(substitute(data))), ...) {
   
   check_as_flights_package_arguments(data, name)
   
+  d <- list(...)
+  
+  if(!(is.null(d$create_path))) {
+    name <- paste(c(as.character(d$create_path), name), collapse = "/")
+  } 
+  
+  if(!(is.null(d$check_name))) {
+    cn <- d$check_name
+  } else {
+    cn <- TRUE
+  }
+  
+  if(!(is.null(d$use_rstudio))) {
+    rs <- d$use_rstudio
+  } else {
+    # only attempt to create it if we're really sure we can
+    if (rstudioapi::isAvailable() && rlang::is_interactive()) {
+      rs <- TRUE
+    } else {
+      warning_glue("the session is not in an appropriate state to create an .RProj file",
+                   "create one manually using rstudioapi::initializeProject()")
+      rs <- FALSE
+    }
+  }
+  
   usethis::create_package(
     path = name,
-    open = FALSE,
     field = list(
       `Authors@R` = 'c(
       person("Simon P.", "Couch", , "simonpatrickcouch@gmail.com", c("aut", "cre")),
@@ -41,7 +65,10 @@ as_flights_package <- function(data, name = make.names(deparse(substitute(data))
       `License` = "CC0",
       `URL` = "http://github.com/simonpcouch/anyflights",
       `BugReports` = "https://github.com/simonpcouch/anyflights/issues",
-      `Suggests` = "anyflights")
+      `Suggests` = "anyflights"),
+    rstudio = rs,
+    check_name = cn,
+    open = FALSE
   )
   
   save_flights_data(data, name)

--- a/man/as_flights_package.Rd
+++ b/man/as_flights_package.Rd
@@ -4,7 +4,7 @@
 \alias{as_flights_package}
 \title{Generate a Data Package from `anyflights` Data}
 \usage{
-as_flights_package(data, name = make.names(deparse(substitute(data))))
+as_flights_package(data, name = make.names(deparse(substitute(data))), ...)
 }
 \arguments{
 \item{data}{A named list of dataframes outputted by 

--- a/tests/testthat/test-7-as-flights-package.R
+++ b/tests/testthat/test-7-as-flights-package.R
@@ -1,7 +1,7 @@
 context("as_flights_package")
 
 test_that("as_flights_package works", {
-  
+
   skip_on_cran()
   skip_on_ci()
   skip_on_os("windows")
@@ -12,13 +12,19 @@ test_that("as_flights_package works", {
                     planes = dplyr::sample_n(nycflights13::planes, 30),
                     airlines = nycflights13::airlines)
   
-  as_flights_package(test_data, "testflights13")
+  create_path <- tempdir()
   
-  expect_true(file.exists("testflights13/R/flights.R"))
-  expect_true(file.exists("testflights13/man/flights.Rd"))
-  expect_true(file.exists("testflights13/data/flights.rda"))
-  expect_true(file.exists("testflights13/testflights13.Rproj"))
+  as_flights_package(test_data, "testflights13", 
+                     create_path = create_path,
+                     check_name = FALSE,
+                     use_rstudio = FALSE)
   
-  unlink("testflights13", recursive = TRUE)
+  package_path = paste0(create_path, "/testflights13")
   
+  expect_true(file.exists(paste0(package_path, "/R/flights.R")))
+  expect_true(file.exists(paste0(package_path, "/man/flights.Rd")))
+  expect_true(file.exists(paste0(package_path, "/data/flights.rda")))
+  
+  unlink(package_path, recursive = TRUE)
+
 })


### PR DESCRIPTION
allows for passing `as_flights_package` test, without altering existing behavior, by:

1. building the package in a temp directory, bypassing the error generated by `usethis::create_package()`
    - using a tmp directory causes the valid CRAN package name check to fail, so we also pass `check_name = FALSE` through this function to `usethis::use_description()`
2. removing the assertion of an `.Rproj` file existing in the package directory
    - `create_package` uses `usethis::use_rstudio()`, which we want if we're creating our own copy of the package. The function tries to place an `.Rproj` file in the package directory, which unfortunately forces a prompt that we can't answer in the non-interactive session, failing the test.

(follow up from #15)
