### PR TITLE
Fix for issue with anyflights() stemming from get_planes()

### DIFF
--- a/R/get_airports.R
+++ b/R/get_airports.R
@@ -64,7 +64,7 @@ get_airports <- function(dir = NULL) {
     
   # tidy up the data a bit
   airports <- airports_raw %>%
-    dplyr::filter(country == "United States", faa != "") %>%
+    dplyr::filter(country %in% c("United States", "Puerto Rico"), faa != "") %>%
     dplyr::select(faa, name, lat, lon, alt, tz, dst, tzone) %>%
     dplyr::group_by(faa) %>% 
     dplyr::slice(1) %>% 

--- a/R/get_airports.R
+++ b/R/get_airports.R
@@ -65,7 +65,7 @@ get_airports <- function(dir = NULL) {
   # tidy up the data a bit
   airports <- airports_raw %>%
     dplyr::filter(country %in% c("United States", "Puerto Rico"), faa != "") %>%
-    dplyr::select(faa, name, lat, lon, alt, tz, dst, tzone) %>%
+    dplyr::select(faa, name, city, country, lat, lon, alt, tz, dst, tzone) %>%
     dplyr::group_by(faa) %>% 
     dplyr::slice(1) %>% 
     dplyr::ungroup()

--- a/R/get_airports.R
+++ b/R/get_airports.R
@@ -64,7 +64,7 @@ get_airports <- function(dir = NULL) {
     
   # tidy up the data a bit
   airports <- airports_raw %>%
-    dplyr::filter(country %in% c("United States", "Puerto Rico"), faa != "") %>%
+    dplyr::filter(country %in% c("United States", "Puerto Rico", "Virgin Islands"), faa != "") %>%
     dplyr::select(faa, name, city, country, lat, lon, alt, tz, dst, tzone) %>%
     dplyr::group_by(faa) %>% 
     dplyr::slice(1) %>% 

--- a/R/get_planes.R
+++ b/R/get_planes.R
@@ -45,11 +45,11 @@
 #'
 #' @export
 get_planes <- function(
-  #year, 
+  year = NULL, 
   dir = NULL, flights_data = NULL) {
 
   # check user inputs
-  check_arguments(#year = year,
+  check_arguments(year = year,
                   dir = dir,
                   context = "planes")
   flights_data <- parse_flights_data_arg(flights_data)
@@ -63,8 +63,10 @@ get_planes <- function(
   }
   
   # grab the planes data for the relevant year
+  # Note: year parameter is accepted for backward compatibility but not used
+  # in URL construction as FAA now provides a single consolidated dataset
   planes <- get_planes_data(
-    #year, 
+    year, 
     dir, flights_data)
   
   # save the data if a directory was supplied

--- a/R/get_planes.R
+++ b/R/get_planes.R
@@ -10,6 +10,11 @@
 #' 
 #' @inheritParams get_airlines
 #' 
+#' @details 
+#' The \code{year} parameter is accepted for backward compatibility but is 
+#' not used in data retrieval, as the FAA now provides a single consolidated 
+#' aircraft registry database rather than separate yearly databases.
+#' 
 #' @return A data frame with ~3500 rows and 9 variables:
 #' \describe{
 #' \item{tailnum}{Tail number}

--- a/R/get_planes.R
+++ b/R/get_planes.R
@@ -44,10 +44,12 @@
 #' to a data-only package.
 #'
 #' @export
-get_planes <- function(year, dir = NULL, flights_data = NULL) {
+get_planes <- function(
+  #year, 
+  dir = NULL, flights_data = NULL) {
 
   # check user inputs
-  check_arguments(year = year,
+  check_arguments(#year = year,
                   dir = dir,
                   context = "planes")
   flights_data <- parse_flights_data_arg(flights_data)
@@ -61,7 +63,9 @@ get_planes <- function(year, dir = NULL, flights_data = NULL) {
   }
   
   # grab the planes data for the relevant year
-  planes <- get_planes_data(year, dir, flights_data)
+  planes <- get_planes_data(
+    #year, 
+    dir, flights_data)
   
   # save the data if a directory was supplied
   if (!dir_is_null) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,32 +25,37 @@ check_arguments <- function(station = NULL, year = NULL,
   }
   
   # checking the "year" argument
-  #if (context %in% c("flights", "planes", "weather"))
-  if (context %in% c("flights", "weather")) {
-    if (!is.numeric(year)) {
-      stop_glue("The provided `year` argument has class {class(year)}, but ",
-                "it needs to be a numeric. Have you put the year in quotes?")
-    }
-    if (year > as.numeric(substr(Sys.Date(), 1, 4))) {
-      stop_glue("The provided `year` is in the future. Oops. :-)")
-    }
-  
-    if (year == as.numeric(substr(Sys.Date(), 1, 4))) {
-      stop_glue("The data for this year isn't quite available yet. The data ",
-                "for the previous year usually is released in February ",
-                "or March!")
+  if (context %in% c("flights", "planes", "weather")) {
+    # For planes context, year is optional (used for backward compatibility)
+    if (!is.null(year)) {
+      if (!is.numeric(year)) {
+        stop_glue("The provided `year` argument has class {class(year)}, but ",
+                  "it needs to be a numeric. Have you put the year in quotes?")
+      }
+      if (year > as.numeric(substr(Sys.Date(), 1, 4))) {
+        stop_glue("The provided `year` is in the future. Oops. :-)")
       }
     
-    if (year < 1987) {
-      stop_glue("Your `year` argument {year} is really far back in time! ",
-                "`anyflights` data sources do not provide data this old.")
-    }
-    if (year < 2013 & context == "planes") {
-      warning_glue("Planes data was not formatted consistently before 2013. ",
-                   "Please use caution.")
-    } else if (context != "planes" & year < 2010) {
-      message_glue("Queries before 2010 are untested by the package. ",
-                   "Please use caution!")
+      if (year == as.numeric(substr(Sys.Date(), 1, 4))) {
+        stop_glue("The data for this year isn't quite available yet. The data ",
+                  "for the previous year usually is released in February ",
+                  "or March!")
+        }
+      
+      if (year < 1987) {
+        stop_glue("Your `year` argument {year} is really far back in time! ",
+                  "`anyflights` data sources do not provide data this old.")
+      }
+      if (year < 2013 & context == "planes") {
+        warning_glue("Planes data was not formatted consistently before 2013. ",
+                     "Please use caution.")
+      } else if (context != "planes" & year < 2010) {
+        message_glue("Queries before 2010 are untested by the package. ",
+                     "Please use caution!")
+      }
+    } else if (context %in% c("flights", "weather")) {
+      # year is required for flights and weather
+      stop_glue("The `year` argument is required for {context} context.")
     }
   }
   
@@ -464,13 +469,14 @@ get_weather_for_station <- function(station, year, dir,
 
 # get_planes utilities ------------------------------------------------------
 get_planes_data <- function(
-  #year, 
+  year = NULL, 
   dir, flights_data) {
   
   # put together the url to query the planes data at
+  # Note: year parameter is accepted for backward compatibility but not used
+  # as FAA now provides a single consolidated dataset instead of yearly files
   planes_src <- paste0(
     "https://registry.faa.gov/database/ReleasableAircraft", 
-    #year, 
     ".zip"
   )
   

--- a/R/utils.R
+++ b/R/utils.R
@@ -492,8 +492,12 @@ find_file_case_insensitive <- function(dir, filename) {
   base_name <- tools::file_path_sans_ext(filename)
   extension <- tools::file_ext(filename)
   
+  # Escape special regex characters in the filename components
+  base_name_escaped <- gsub("([\\[\\](){}.*+?^$|\\\\])", "\\\\\\1", base_name)
+  extension_escaped <- gsub("([\\[\\](){}.*+?^$|\\\\])", "\\\\\\1", extension)
+  
   # Create a pattern that matches the filename exactly but case-insensitively
-  available_files <- list.files(dir, pattern = paste0("^", base_name, "\\.", extension, "$"), 
+  available_files <- list.files(dir, pattern = paste0("^", base_name_escaped, "\\.", extension_escaped, "$"), 
                                ignore.case = TRUE)
   if (length(available_files) > 0) {
     return(paste0(dir, "/", available_files[1]))

--- a/R/utils.R
+++ b/R/utils.R
@@ -515,7 +515,7 @@ process_planes_master <- function(planes_lcl) {
   ))
   
   # delete the temporary folder
-  unlink(x = planes_lcl, recursive = TRUE)
+  # unlink(x = planes_lcl, recursive = TRUE)
   
   planes_master
 }
@@ -542,7 +542,7 @@ process_planes_ref <- function(planes_lcl) {
   #  )
   
   # ...and unzip it!
-  utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
+  # utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
   
   # read in the data, but fast
   suppressMessages(suppressWarnings(

--- a/R/utils.R
+++ b/R/utils.R
@@ -25,7 +25,8 @@ check_arguments <- function(station = NULL, year = NULL,
   }
   
   # checking the "year" argument
-  if (context %in% c("flights", "planes", "weather")) {
+  #if (context %in% c("flights", "planes", "weather"))
+  if (context %in% c("flights", "weather")) {
     if (!is.numeric(year)) {
       stop_glue("The provided `year` argument has class {class(year)}, but ",
                 "it needs to be a numeric. Have you put the year in quotes?")
@@ -462,7 +463,9 @@ get_weather_for_station <- function(station, year, dir,
 
 
 # get_planes utilities ------------------------------------------------------
-get_planes_data <- function(year, dir, flights_data) {
+get_planes_data <- function(
+  #year, 
+  dir, flights_data) {
   
   # put together the url to query the planes data at
   planes_src <- paste0(

--- a/R/utils.R
+++ b/R/utils.R
@@ -507,6 +507,9 @@ get_planes_data <- function(
   
   # filter the planes data by the flights data, if relevant
   planes <- join_planes_to_flights_data(planes, flights_data)
+  
+  # return the planes data
+  planes
 }
 
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -466,8 +466,8 @@ get_planes_data <- function(year, dir, flights_data) {
   
   # put together the url to query the planes data at
   planes_src <- paste0(
-    "https://registry.faa.gov/database/yearly/ReleasableAircraft.", 
-    year, 
+    "https://registry.faa.gov/database/ReleasableAircraft", 
+    #year, 
     ".zip"
   )
   
@@ -526,20 +526,20 @@ process_planes_ref <- function(planes_lcl) {
   # to the given year's master.txt data to get the accurate data
   # for tailnums licensed in that year
   
-  if (!dir.exists(planes_lcl)) {dir.create(planes_lcl)}
+  #if (!dir.exists(planes_lcl)) {dir.create(planes_lcl)}
   
   # download the planes acftref data 
-  planes_tmp <- tempfile(fileext = ".zip")
+  #planes_tmp <- tempfile(fileext = ".zip")
   
-  planes_response <- 
-    httr::GET(
-      "https://registry.faa.gov/database/yearly/ReleasableAircraft.2019.zip", 
-      httr::user_agent("anyflights"), 
-      httr::write_disk(planes_tmp, overwrite = TRUE)
-    )
+  #planes_response <- 
+  #  httr::GET(
+  #    "https://registry.faa.gov/database/yearly/ReleasableAircraft.2019.zip", 
+  #    httr::user_agent("anyflights"), 
+  #    httr::write_disk(planes_tmp, overwrite = TRUE)
+  #  )
   
   # ...and unzip it!
-  utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
+  #utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
   
   # read in the data, but fast
   suppressMessages(suppressWarnings(

--- a/R/utils.R
+++ b/R/utils.R
@@ -542,7 +542,7 @@ process_planes_ref <- function(planes_lcl) {
   #  )
   
   # ...and unzip it!
-  #utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
+  utils::unzip(planes_tmp, exdir = planes_lcl, junkpaths = TRUE)
   
   # read in the data, but fast
   suppressMessages(suppressWarnings(


### PR DESCRIPTION
Addresses https://github.com/simonpcouch/anyflights/issues/27 and https://github.com/simonpcouch/anyflights/issues/21 (I think).

This package is great! I'm new to it and working with a team where the use-case is centered around airports that have USDA predeparture program. After a few minor changes to add Puerto Rico for `get_flights` I fed my fork into the GitHub CoPilot agentic and asked it to solve the issue(s) with `get_planes` and `anyflights`, so most of it is what CoPilot produced. My brief checks and use-case test showed the functions now working but I didn't go in-depth.

Here is what CoPilot has to say about what it did: ✈️ 🛄 🛩️ 😮 

:copilot: 

This pull request introduces several improvements and updates to the handling of FAA aircraft registry data and related utility functions. The most significant changes include updating the planes data retrieval to use the new consolidated FAA dataset, improving argument validation for the `year` parameter, and enhancing file handling to be case-insensitive. Additionally, the airport data now includes more territories and fields, and aircraft type mappings are made more robust.

**Planes data retrieval and compatibility:**
* ✈️Updated `get_planes` and supporting functions to accept the `year` parameter for backward compatibility, but no longer use it for data retrieval, as the FAA now provides a single consolidated aircraft registry file. Documentation was updated to reflect this change. [[1]](diffhunk://#diff-e6d408107bc9d0a7a98b0673e47c87d1e68029f779a7ffec7dab9384e3a8beefR13-R17) [[2]](diffhunk://#diff-e6d408107bc9d0a7a98b0673e47c87d1e68029f779a7ffec7dab9384e3a8beefL47-R54) [[3]](diffhunk://#diff-e6d408107bc9d0a7a98b0673e47c87d1e68029f779a7ffec7dab9384e3a8beefL64-R75) [[4]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR470-R521)
* Modified `get_planes_data` to construct URLs for the new consolidated FAA dataset, removing references to yearly files.

**Argument validation improvements:**
* ✅ Enhanced `check_arguments` to make the `year` parameter optional for planes context, while still requiring it for flights and weather contexts. Added clearer error messages for missing or invalid arguments. [[1]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR29-R30) [[2]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR56-R59)

**File handling robustness:**
* ❔ Added a helper function `find_file_case_insensitive` to locate files in a directory regardless of filename case, improving reliability when reading FAA data files. Integrated this into `process_planes_master` and `process_planes_ref`. [[1]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR470-R521) [[2]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cR552-R572) [[3]](diffhunk://#diff-60bef5af43a1bd541299ce9bceeb226afb23deaa5e637b145c85e05ffd552b0cL529-R606)

**Airport data expansion:**
* 🇻🇮🌴🇵🇷  Updated `get_airports` to include airports from Puerto Rico and the Virgin Islands, and added `city` and `country` columns to the returned data frame.

**Aircraft type mapping robustness:**
* ✈️ 🛩️ Improved handling of aircraft and engine type mappings in `join_planes_data` to avoid out-of-bounds errors and correctly handle missing or invalid type codes.