### PR TITLE
Add default value for year parameter in get_planes

### DIFF
--- a/R/get_planes.R
+++ b/R/get_planes.R
@@ -44,7 +44,7 @@
 #' to a data-only package.
 #'
 #' @export
-get_planes <- function(year, dir = NULL, flights_data = NULL) {
+get_planes <- function(year = NULL, dir = NULL, flights_data = NULL) {
 
   # check user inputs
   check_arguments(year = year,

--- a/R/get_planes.R
+++ b/R/get_planes.R
@@ -9,6 +9,8 @@
 #' @inheritParams anyflights 
 #' 
 #' @inheritParams get_airlines
+#'
+#' @param year The argument will be ignored and is present only for backward-compatibility
 #' 
 #' @return A data frame with ~3500 rows and 9 variables:
 #' \describe{


### PR DESCRIPTION
Make default NULL because FAA doesn't provide data by year. Related to changes made in the underlying functions of get_planes in patch-1.