### PR TITLE
Fix issue #28

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,7 @@ Imports:
     tidyr
 URL: https://github.com/simonpcouch/anyflights, https://simonpcouch.github.io/anyflights/
 BugReports: https://github.com/simonpcouch/anyflights/issues
-RoxygenNote: 7.3.2
+RoxygenNote: 7.3.3
 Encoding: UTF-8
 Suggests: 
     testthat,

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,12 @@
 # anyflights (development version)
 
+* `time_hour` in both `get_flights()` and `get_weather()` is now tagged with
+  each origin airport's local IANA time zone (looked up from
+  `get_airports()$tzone`), matching the convention used by `nycflights13`.
+  This makes the `(origin, time_hour)` join between flights and weather
+  return correct results across multiple time zones, where previously the
+  two columns disagreed for any non-UTC airport (#28, @ismayc).
+
 # anyflights 0.3.5
 
 * Include `tz = "GMT"` argument to `ISOdatetime()` so that weather output isn't 

--- a/R/get_flights.R
+++ b/R/get_flights.R
@@ -34,9 +34,10 @@
 #'   \code{\link{get_airports}} for additional metadata.}
 #' \item{\code{air_time}}{Amount of time spent in the air, in minutes}
 #' \item{\code{distance}}{Distance between airports, in miles}
-#' \item{\code{time_hour}}{Scheduled date and hour of the flight as a 
-#'   \code{POSIXct} date. Along with \code{origin}, can be used to join 
-#'   flights data to weather data.}
+#' \item{\code{time_hour}}{Scheduled date and hour of the flight as a
+#'   \code{POSIXct} date in the airport's local time zone (IANA \code{tzone}
+#'   from \code{\link{get_airports}}). Along with \code{origin}, can be used
+#'   to join flights data to weather data.}
 #' }
 #' 
 #' @note
@@ -122,7 +123,10 @@ get_flights <- function(station, year, month = 1:12, dir = NULL, ...) {
                         station = station) %>%
     dplyr::bind_rows() %>%
     dplyr::arrange(year, month, day, dep_time)
-  
+
+  # tag time_hour with each origin's local IANA time zone (#28)
+  flights <- adjust_time_hour_tz(flights, get_airports(), action = "force")
+
   # get rid of the "raw" data
   unlink(x = flight_exdir, recursive = TRUE)
     

--- a/R/get_weather.R
+++ b/R/get_weather.R
@@ -10,9 +10,10 @@
 #' 
 #' @return A data frame with ~1k-25k rows and 15 variables:
 #' \describe{
-#' \item{\code{origin}}{Weather station. Named \code{origin} to facilitate 
+#' \item{\code{origin}}{Weather station. Named \code{origin} to facilitate
 #'   merging with flights data}
-#' \item{\code{year, month, day, hour}}{Time of recording, UTC}
+#' \item{\code{year, month, day, hour}}{Time of recording in the airport's
+#'   local time zone.}
 #' \item{\code{temp, dewp}}{Temperature and dewpoint in F}
 #' \item{\code{humid}}{Relative humidity}
 #' \item{\code{wind_dir, wind_speed, wind_gust}}{Wind direction (in degrees), 
@@ -20,8 +21,10 @@
 #' \item{\code{precip}}{Precipitation, in inches}
 #' \item{\code{pressure}}{Sea level pressure in millibars}
 #' \item{\code{visib}}{Visibility in miles}
-#' \item{\code{time_hour}}{Date and hour of the recording as a \code{POSIXct} 
-#'   date, UTC}
+#' \item{\code{time_hour}}{Date and hour of the recording as a \code{POSIXct}
+#'   date in the airport's local time zone (IANA \code{tzone} from
+#'   \code{\link{get_airports}}). Along with \code{origin}, can be used to
+#'   join weather data to flights data.}
 #' }
 #' @source ASOS download from Iowa Environmental Mesonet,
 #'   \url{https://mesonet.agron.iastate.edu/request/download.phtml}
@@ -66,14 +69,17 @@ get_weather <- function(station, year, month = 1:12, dir = NULL) {
     dir_is_null <- FALSE
   }
   
-  weather <- purrr::map(station, 
-                            get_weather_for_station, 
+  weather <- purrr::map(station,
+                            get_weather_for_station,
                             year = year,
-                            dir = dir, 
+                            dir = dir,
                             month_and_day_range = month_and_day_range,
                             month = month) %>%
     dplyr::bind_rows()
-  
+
+  # convert time_hour to each origin's local IANA time zone (#28)
+  weather <- adjust_time_hour_tz(weather, get_airports(), action = "convert")
+
   # save the data if the user supplied a directory
   if (!dir_is_null) {
     save(weather, file = paste0(dir, "/weather.rda"), compress = "xz")

--- a/R/utils.R
+++ b/R/utils.R
@@ -198,6 +198,42 @@ download_file_wrapper <- function(url, file_path, quiet = TRUE){
   out
 }
 
+# Adjust `time_hour` so it carries the airport's local IANA time zone, matching
+# nycflights13's convention. Flights data arrives with airport-local wall clocks
+# implicitly tagged as UTC, so `force_tz` keeps the wall clock and corrects the
+# instant. Weather data arrives with true-UTC instants, so `with_tz` preserves
+# the instant and shifts the wall clock to the airport's tz; we then recompute
+# year/month/day/hour from the converted time_hour. Both modes group by `tzone`
+# because lubridate's tz functions accept only one zone per call.
+adjust_time_hour_tz <- function(data, airports_data, action = c("force", "convert")) {
+  action <- match.arg(action)
+  data %>%
+    dplyr::left_join(
+      dplyr::select(airports_data, faa, tzone),
+      by = c("origin" = "faa")
+    ) %>%
+    dplyr::group_by(tzone) %>%
+    dplyr::group_modify(~ {
+      tz <- .y$tzone
+      if (is.na(tz)) return(.x)
+      if (action == "force") {
+        dplyr::mutate(.x, time_hour = lubridate::force_tz(time_hour, tzone = tz))
+      } else {
+        dplyr::mutate(
+          .x,
+          time_hour = lubridate::with_tz(time_hour, tzone = tz),
+          year = as.integer(lubridate::year(time_hour)),
+          month = as.integer(lubridate::month(time_hour)),
+          day = as.integer(lubridate::mday(time_hour)),
+          hour = as.integer(lubridate::hour(time_hour))
+        )
+      }
+    }) %>%
+    dplyr::ungroup() %>%
+    dplyr::select(-tzone)
+}
+
+
 # get_flights utilities --------------------------------------------------
 
 download_month <- function(year, month, dir, flight_exdir, pb, diff_fn) {

--- a/man/get_flights.Rd
+++ b/man/get_flights.Rd
@@ -45,9 +45,10 @@ A data frame with ~1k-500k rows and 19 variables:
   \code{\link{get_airports}} for additional metadata.}
 \item{\code{air_time}}{Amount of time spent in the air, in minutes}
 \item{\code{distance}}{Distance between airports, in miles}
-\item{\code{time_hour}}{Scheduled date and hour of the flight as a 
-  \code{POSIXct} date. Along with \code{origin}, can be used to join 
-  flights data to weather data.}
+\item{\code{time_hour}}{Scheduled date and hour of the flight as a
+  \code{POSIXct} date in the airport's local time zone (IANA \code{tzone}
+  from \code{\link{get_airports}}). Along with \code{origin}, can be used
+  to join flights data to weather data.}
 }
 }
 \description{

--- a/man/get_weather.Rd
+++ b/man/get_weather.Rd
@@ -27,9 +27,10 @@ to save datasets in. By default, datasets will not be saved to file.}
 \value{
 A data frame with ~1k-25k rows and 15 variables:
 \describe{
-\item{\code{origin}}{Weather station. Named \code{origin} to facilitate 
+\item{\code{origin}}{Weather station. Named \code{origin} to facilitate
   merging with flights data}
-\item{\code{year, month, day, hour}}{Time of recording, UTC}
+\item{\code{year, month, day, hour}}{Time of recording in the airport's
+  local time zone.}
 \item{\code{temp, dewp}}{Temperature and dewpoint in F}
 \item{\code{humid}}{Relative humidity}
 \item{\code{wind_dir, wind_speed, wind_gust}}{Wind direction (in degrees), 
@@ -37,8 +38,10 @@ A data frame with ~1k-25k rows and 15 variables:
 \item{\code{precip}}{Precipitation, in inches}
 \item{\code{pressure}}{Sea level pressure in millibars}
 \item{\code{visib}}{Visibility in miles}
-\item{\code{time_hour}}{Date and hour of the recording as a \code{POSIXct} 
-  date, UTC}
+\item{\code{time_hour}}{Date and hour of the recording as a \code{POSIXct}
+  date in the airport's local time zone (IANA \code{tzone} from
+  \code{\link{get_airports}}). Along with \code{origin}, can be used to
+  join weather data to flights data.}
 }
 }
 \description{

--- a/tests/testthat/test-8-time-hour-tz.R
+++ b/tests/testthat/test-8-time-hour-tz.R
@@ -1,0 +1,168 @@
+context("adjust_time_hour_tz")
+
+# A small in-memory airports lookup so these tests don't hit the network.
+mock_airports <- function() {
+  tibble::tibble(
+    faa   = c("PDX", "JFK", "DEN", "HNL", "XYZ"),
+    tzone = c(
+      "America/Los_Angeles",
+      "America/New_York",
+      "America/Denver",
+      "Pacific/Honolulu",
+      NA_character_
+    )
+  )
+}
+
+test_that("force mode preserves wall clock and corrects the instant per origin", {
+  # Simulates raw flights data: airport-local wall clock implicitly tagged UTC
+  flights <- tibble::tibble(
+    origin    = c("PDX", "JFK", "DEN"),
+    time_hour = lubridate::make_datetime(2023, 1, 1, c(9, 9, 9), 0, 0)
+  )
+
+  out <- anyflights:::adjust_time_hour_tz(
+    flights, mock_airports(), action = "force"
+  )
+
+  # Output is a tibble with the original columns (no tzone leaking through)
+  expect_setequal(colnames(out), c("origin", "time_hour"))
+  expect_s3_class(out$time_hour, "POSIXct")
+
+  # Each origin's instant should equal "9am at airport local tz"
+  expected <- c(
+    PDX = as.numeric(as.POSIXct("2023-01-01 09:00:00", tz = "America/Los_Angeles")),
+    JFK = as.numeric(as.POSIXct("2023-01-01 09:00:00", tz = "America/New_York")),
+    DEN = as.numeric(as.POSIXct("2023-01-01 09:00:00", tz = "America/Denver"))
+  )
+  by_origin <- stats::setNames(as.numeric(out$time_hour), out$origin)
+  expect_equal(by_origin[names(expected)], expected)
+})
+
+test_that("convert mode preserves the instant and recomputes airport-local components", {
+  # Simulates raw weather data: true UTC instants of observations and
+  # year/month/day/hour columns derived in UTC.
+  weather <- tibble::tibble(
+    origin    = c("PDX", "JFK", "DEN"),
+    year      = 2023L,
+    month     = 1L,
+    day       = 1L,
+    # 09:00 airport-local in each tz, expressed as UTC hour
+    hour      = c(17L, 14L, 16L),
+    time_hour = ISOdatetime(2023, 1, 1, c(17, 14, 16), 0, 0, tz = "GMT")
+  )
+
+  out <- anyflights:::adjust_time_hour_tz(
+    weather, mock_airports(), action = "convert"
+  )
+
+  expect_setequal(
+    colnames(out),
+    c("origin", "year", "month", "day", "hour", "time_hour")
+  )
+  expect_s3_class(out$time_hour, "POSIXct")
+
+  # Underlying instants are preserved (with_tz, not force_tz)
+  in_by  <- stats::setNames(as.numeric(weather$time_hour), weather$origin)
+  out_by <- stats::setNames(as.numeric(out$time_hour),     out$origin)
+  expect_equal(out_by[names(in_by)], in_by)
+
+  # year/month/day/hour are recomputed in airport-local time => 9am everywhere
+  expect_equal(out$hour, rep(9L, 3))
+  expect_equal(out$year, rep(2023L, 3))
+  expect_equal(out$month, rep(1L, 3))
+  expect_equal(out$day, rep(1L, 3))
+})
+
+test_that("flights and weather time_hour join across multiple time zones (issue #28)", {
+  airports <- mock_airports()
+  origins  <- c("PDX", "JFK", "DEN", "HNL")
+
+  # Flights data: airport-local 9am scheduled departure
+  flights <- tibble::tibble(
+    origin    = origins,
+    time_hour = lubridate::make_datetime(2023, 1, 1, 9, 0, 0)
+  ) %>%
+    anyflights:::adjust_time_hour_tz(airports, action = "force")
+
+  # Weather data: UTC observation at the corresponding instant
+  utc_hour <- c(PDX = 17L, JFK = 14L, DEN = 16L, HNL = 19L)
+  weather <- tibble::tibble(
+    origin    = names(utc_hour),
+    year      = 2023L, month = 1L, day = 1L,
+    hour      = unname(utc_hour),
+    time_hour = ISOdatetime(2023, 1, 1, unname(utc_hour), 0, 0, tz = "GMT")
+  ) %>%
+    anyflights:::adjust_time_hour_tz(airports, action = "convert")
+
+  joined <- dplyr::inner_join(flights, weather, by = c("origin", "time_hour"))
+  expect_equal(nrow(joined), length(origins))
+  expect_setequal(joined$origin, origins)
+})
+
+test_that("NA tzone leaves time_hour unchanged", {
+  raw <- tibble::tibble(
+    origin    = c("XYZ", "XYZ"),
+    time_hour = lubridate::make_datetime(2023, 1, 1, c(9, 10), 0, 0)
+  )
+
+  for (action in c("force", "convert")) {
+    out <- anyflights:::adjust_time_hour_tz(raw, mock_airports(), action = action)
+    expect_equal(as.numeric(out$time_hour), as.numeric(raw$time_hour),
+                 info = paste("action =", action))
+  }
+})
+
+test_that("single-tz input matches nycflights13 convention", {
+  # nycflights13 has all origins in one zone; check we replicate that shape.
+  flights <- tibble::tibble(
+    origin    = c("JFK", "LGA", "EWR"),
+    time_hour = lubridate::make_datetime(2023, 6, 15, c(8, 12, 20), 0, 0)
+  )
+  airports <- tibble::tibble(
+    faa   = c("JFK", "LGA", "EWR"),
+    tzone = rep("America/New_York", 3)
+  )
+
+  out <- anyflights:::adjust_time_hour_tz(flights, airports, action = "force")
+
+  expect_equal(lubridate::tz(out$time_hour), "America/New_York")
+  # Wall clock preserved per origin
+  expect_equal(lubridate::hour(out$time_hour[out$origin == "JFK"]), 8)
+  expect_equal(lubridate::hour(out$time_hour[out$origin == "LGA"]), 12)
+  expect_equal(lubridate::hour(out$time_hour[out$origin == "EWR"]), 20)
+})
+
+test_that("the bind across mixed tzs preserves underlying instants", {
+  # Even though POSIXct can carry only one tz attribute on a column, the
+  # *instants* must remain correct after combining groups, so downstream
+  # joins on time_hour return the right rows.
+  flights <- tibble::tibble(
+    origin    = c("PDX", "JFK", "DEN"),
+    time_hour = lubridate::make_datetime(2023, 7, 4, c(6, 6, 6), 0, 0)
+  )
+  out <- anyflights:::adjust_time_hour_tz(flights, mock_airports(), action = "force")
+
+  # Round-trip: shift instants back by airports$tzone and we should recover
+  # the original UTC wall clock (6am everywhere).
+  recovered <- purrr::map2_dbl(
+    out$origin,
+    out$time_hour,
+    function(o, t) {
+      tz <- mock_airports()$tzone[mock_airports()$faa == o]
+      as.numeric(lubridate::with_tz(t, tz))
+    }
+  )
+  expect_equal(recovered, as.numeric(out$time_hour))
+
+  # Hour, when read in each origin's local tz, is always 6
+  local_hour <- purrr::map2_int(
+    out$origin,
+    out$time_hour,
+    function(o, t) {
+      tz <- mock_airports()$tzone[mock_airports()$faa == o]
+      as.integer(lubridate::hour(lubridate::with_tz(t, tz)))
+    }
+  )
+  expect_equal(local_hour, rep(6L, 3))
+})


### PR DESCRIPTION
It only took me a year! 😅 

`get_flights()` previously returned `time_hour` with airport-local wall clocks implicitly tagged as UTC, while `get_weather()` returned true UTC instants tagged as GMT. The two columns therefore disagreed for any non-UTC origin and the canonical `(origin, time_hour)` join produced no rows. After this change both functions return `time_hour` in the airport's IANA `tzone` (looked up from `get_airports()`), matching `nycflights13`'s convention: flights are forced into the local zone (wall clock preserved, instant corrected) and weather is converted into the local zone (instant preserved, wall clock + year/month/day/hour recomputed). New unit tests in `test-8-time-hour-tz.R` exercise both modes and lock in the cross-table join invariant.